### PR TITLE
docs: use --project-path for ockam node create

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ python3 -m http.server --bind 127.0.0.1 5000
 # In a new terminal window, setup an ockam node, called `s`, as a sidecar next to the 
 # application service. Then create a tcp outlet, on the `s` node, to send raw tcp traffic
 # to the service. Finally create a forwarder in your default Orchestrator project.
-ockam node create s --project default-project.json
+ockam node create s --project-path default-project.json
 ockam tcp-outlet create --at s --from /service/outlet --to 127.0.0.1:5000
 ockam forwarder create s --at /project/default --to s
 
@@ -87,7 +87,7 @@ ockam forwarder create s --at /project/default --to s
 # Setup an ockam node, called `c`, as a sidecar next to our application client. Then create
 # an end-to-end encrypted secure channel with s, through the cloud relay. Finally, tunnel
 # traffic from a local tcp inlet through this end-to-end secure channel.
-ockam node create c --project default-project.json
+ockam node create c --project-path default-project.json
 ockam secure-channel create --from c --to /project/default/service/forward_to_s/service/api\
   | ockam tcp-inlet create --at c --from 127.0.0.1:7000 --to -/service/outlet
 

--- a/guides/examples/basic-web-app.md
+++ b/guides/examples/basic-web-app.md
@@ -73,7 +73,7 @@ Next we're going to create and enroll a new Ockam node on our project, we'll add
 export PG_PORT=5433
 ockam identity create db
 ockam project authenticate --identity db --token $DB_TOKEN --project-path project.json
-ockam node create db --project project.json --identity db
+ockam node create db --project-path project.json --identity db
 ockam policy set --at db --resource tcp-outlet --expression '(= subject.component "web")'
 ockam tcp-outlet create --at /node/db --from /service/outlet --to 127.0.0.1:$PG_PORT
 ockam forwarder create db --to /node/db --at /project/default
@@ -92,7 +92,7 @@ Next we'll create and enroll our node, set a policy to say it is only allowed to
 ```bash
 ockam identity create web
 ockam project authenticate --identity web --token $WEB_TOKEN --project-path project.json
-ockam node create web --project project.json --identity web
+ockam node create web --project-path project.json --identity web
 ockam policy set --at web --resource tcp-inlet --expression '(= subject.component "db")'
 ockam tcp-inlet create --at /node/web --from 127.0.0.1:5432 --to /project/default/service/forward_to_db/secure/api/service/outlet
 ```

--- a/guides/examples/end-to-end-encrypted-kafka.md
+++ b/guides/examples/end-to-end-encrypted-kafka.md
@@ -83,7 +83,7 @@ ockam project authenticate --project-path project.json \
 An Ockam node is a way to connect securely connect different services to each other, so we'll create one here that we'll use to communicate through the Confluent Cloud cluster using the identity we just created:
 
 ```bash
-ockam node create consumer --project project.json --identity consumer
+ockam node create consumer --project-path project.json --identity consumer
 ```
 
 Once that completes we can now expose our Kafka bootstrap server. This is like the remote Kafka bootsrtap server and brokers have become virtually adjacent on `localhost:4000`:
@@ -128,7 +128,7 @@ ockam project authenticate --project-path project.json \
 Create a node and link it to both the project and identity we've created:
 
 ```bash
-ockam node create producer1 --project project.json --identity producer1
+ockam node create producer1 --project-path project.json --identity producer1
 ```
 
 And expose our Kafka bootstrap server on port `5000` so we can start sending messages through Confluent Cloud:
@@ -159,7 +159,7 @@ Connecting a second product is a matter of repeating the steps above with a new 
 ```
 ockam identity create producer2
 ockam project authenticate --project-path project.json --identity producer2 --token $(cat producer2.token)
-ockam node create producer2 --project project.json --identity producer2
+ockam node create producer2 --project-path project.json --identity producer2
 
 ockam service start kafka-producer --node producer2 --project-route /project/default --bootstrap-server-ip 127.0.0.1 --bootstrap-server-port 6000 --brokers-port-range 6001-6100
 

--- a/guides/examples/telegraf-+-influxdb.md
+++ b/guides/examples/telegraf-+-influxdb.md
@@ -130,7 +130,7 @@ Now we can create a node for our InfluxDB service:
 ```bash
 ockam identity create influxdb
 ockam project authenticate --identity influxdb --token $OCKAM_INFLUXDB_TOKEN --project-path project.json
-ockam node create influxdb --project project.json --identity influxdb
+ockam node create influxdb --project-path project.json --identity influxdb
 ockam policy set --at influxdb --resource tcp-outlet --expression '(= subject.component "telegraf")'
 ockam tcp-outlet create --at /node/influxdb --from /service/outlet --to 127.0.0.1:8086
 ockam forwarder create influxdb --at /project/default --to /node/influxdb
@@ -148,7 +148,7 @@ It's now time to establish the other side of this connection by creating the cor
 ```bash
 ockam identity create telegraf
 ockam project authenticate --identity telegraf --token $OCKAM_TELEGRAF_TOKEN --project-path project.json
-ockam node create telegraf --project project.json --identity telegraf
+ockam node create telegraf --project-path project.json --identity telegraf
 ockam policy set --at telegraf --resource tcp-inlet --expression '(= subject.component "influxdb")'
 ockam tcp-inlet create --at /node/telegraf --from 127.0.0.1:8087 --to /project/default/service/forward_to_influxdb/secure/api/service/outlet
 ```

--- a/guides/use-cases/apply-fine-grained-permissions-with-attribute-based-access-control-abac.md
+++ b/guides/use-cases/apply-fine-grained-permissions-with-attribute-based-access-control-abac.md
@@ -114,7 +114,7 @@ ockam identity create control_identity
 ockam project authenticate --token $cp1_token --identity control_identity
 
 # Create a node targeting the project as the control identity.
-ockam node create control_plane1 --project project.json --identity control_identity
+ockam node create control_plane1 --project-path project.json --identity control_identity
 
 # Set a policy, create the tcp-outlet and forwarder.
 ockam policy set --at control_plane1 --resource tcp-outlet --expression '(= subject.component "edge")'
@@ -130,7 +130,7 @@ ockam identity create edge_identity
 ockam project authenticate --token $ep1_token --identity edge_identity
 <strong>
 </strong><strong># Create a node targeting the project as the edge identity.
-</strong><strong>ockam node create edge_plane1 --project project.json --identity edge_identity
+</strong><strong>ockam node create edge_plane1 --project-path project.json --identity edge_identity
 </strong>
 # Set a policy, and create the tcp-inlet.
 ockam policy set --at edge_plane1 --resource tcp-inlet --expression '(= subject.component "control")'
@@ -158,7 +158,7 @@ ockam identity create x_identity
 ockam project authenticate --token $x_token --identity x_identity
 
 # Create a node targeting the project as the x identity.
-ockam node create x --project project.json --identity x_identity
+ockam node create x --project-path project.json --identity x_identity
 
 # Set a policy and create a new tcp-inlet for node x.
 ockam policy set --at x --resource tcp-inlet --expression '(= subject.component "control")'

--- a/guides/use-cases/use-employee-attributes-from-okta-to-build-trust-with-cryptographically-verifiable-credentials.md
+++ b/guides/use-cases/use-employee-attributes-from-okta-to-build-trust-with-cryptographically-verifiable-credentials.md
@@ -123,7 +123,7 @@ Next we transfer project configuration and one enrollment token to Machine 1 and
 ```bash
 ockam identity create m1
 ockam project authenticate --token $m1_token --identity m1 --project-path project.json
-ockam node create m1 --project project.json --identity m1
+ockam node create m1 --project-path project.json --identity m1
 ockam policy set --at m1 --resource tcp-outlet \
   --expression '(or (= subject.application "Smart Factory") (and (= subject.department "Field Engineering") (= subject.city "San Francisco")))'
 ockam tcp-outlet create --at /node/m1 --from /service/outlet --to 127.0.0.1:5000
@@ -152,7 +152,7 @@ Next we transfer project configuration and one enrollment token to Machine 2 and
 ```bash
 ockam identity create m2
 ockam project authenticate --token $m2_token --identity m2 --project-path project.json
-ockam node create m2 --project project.json --identity m2
+ockam node create m2 --project-path project.json --identity m2
 ockam policy set --at m2 --resource tcp-outlet \
   --expression '(or (= subject.application "Smart Factory") (and (= subject.department "Field Engineering") (= subject.city "New York")))'
 ockam tcp-outlet create --at /node/m2 --from /service/outlet --to 127.0.0.1:6000
@@ -173,7 +173,7 @@ There is a problem in one of the micro-services in San Francisco and we need to 
 Since the Okta Add-On is enabled. Alice can simple start a node within the project and authenticate.
 
 ```bash
-ockam node create alice --project project.json
+ockam node create alice --project-path project.json
 ockam project authenticate --project-path project.json --okta
 ockam policy set --at alice --resource tcp-inlet --expression '(= subject.application "Smart Factory")'
 ```

--- a/reference/command/credentials.md
+++ b/reference/command/credentials.md
@@ -126,8 +126,8 @@ HELLO
 » ockam node delete --all
 » ockam project information --output json > project.json
 
-» ockam node create a --project project.json
-» ockam node create b --project project.json
+» ockam node create a --project-path project.json
+» ockam node create b --project-path project.json
 
 » ockam forwarder create b --at /project/default --to /node/a
 /service/forward_to_b

--- a/reference/command/secure-channels.md
+++ b/reference/command/secure-channels.md
@@ -166,8 +166,8 @@ The [<mark style="color:blue;">Project</mark>](nodes.md#project) that was create
 » ockam node delete --all
 » ockam project information --output json > project.json
 
-» ockam node create a --project project.json
-» ockam node create b --project project.json
+» ockam node create a --project-path project.json
+» ockam node create b --project-path project.json
 
 » ockam forwarder create b --at /project/default --to /node/a
 /service/forward_to_b


### PR DESCRIPTION
Currently with the changes related to trust context and and it's implementation

`ockam node create --project`, was moved inline with the rest of the command's arguments to use `--project-path` when referencing a path.


There will be future changes again, to ideally move all `--x-path` arguments to `--x` and allowing the clap parsers to determine if it's a path or state name.
