### PR TITLE
fix typos in the okta addon example doc

### DIFF
--- a/guides/use-cases/use-employee-attributes-from-okta-to-build-trust-with-cryptographically-verifiable-credentials.md
+++ b/guides/use-cases/use-employee-attributes-from-okta-to-build-trust-with-cryptographically-verifiable-credentials.md
@@ -16,7 +16,7 @@ In order to trust information or instructions, that are received over the networ
 
 Applications must also decide if a sender of a request is **authorized** to trigger the requested action or view the requested data.
 
-In scenarios where human users are authenticating with cloud services, we have some mature protocols like OAuth 2.0 and OpenID Connect (OIDC) that help tackle parts of the problem. However, majority of data that flows within modern applications doesn’t involve humans. Microservices interact with other microservices, devices interact with other devices and cloud services, internal services interact with partner systems and infrastructure services etc.
+In scenarios where human users are authenticating with cloud services, we have some mature protocols like OAuth 2.0 and OpenID Connect (OIDC) that help tackle parts of the problem. However, the majority of data that flows within modern applications doesn’t involve humans. Microservices interact with other microservices, devices interact with other devices and cloud services, internal services interact with partner systems and infrastructure services etc.
 
 **Secure** **by-design** applications must ensure that all machine-to-machine application layer communication is authenticated and authorized. For this, **applications must prove identifiers and attributes.**
 
@@ -26,13 +26,13 @@ Ockam makes it simple to safely generate unique **cryptographically provable ide
 
 On this foundation of mutually authenticated secure channels that guarantee end-to-end data authenticity, integrity and confidentiality, we give you tools to make fine-grained trust and authorization decisions.
 
-One simple model of trust and authorization that is possible using only cryptographically provable identifiers is Access Control Lists (ACLs). A resource server is given a list of identifiers that it will allow access to a resource through an authenticated channel. This works great for simple scenarios but is hard to scale. As new clients or users need access to this resource, the access control list has to updated.
+One simple model of trust and authorization that is possible using only cryptographically provable identifiers is Access Control Lists (ACLs). A resource server is given a list of identifiers that it will allow access to a resource through an authenticated channel. This works great for simple scenarios but is hard to scale. As new clients or users need access to this resource, the access control list has to be updated.
 
 A much more powerful and scalable model becomes feasible with cryptographically provable credentials
 
 ### Authenticated Attributes and Cryptographic Credentials
 
-When making fine-grained trust and access control decisions, applications often need to reason about the properties or attributes of an entity that is requesting access to a resource or reporting some data. For example, an application may require that its inventory micorservice is the only service that is allowed to report the current status of inventory. For this to work, applications need to a way to authenticate attributes.
+When making fine-grained trust and access control decisions, applications often need to reason about the properties or attributes of an entity that is requesting access to a resource or reporting some data. For example, an application may require that its inventory microservice is the only service that is allowed to report the current status of inventory. For this to work, applications need a way to authenticate attributes.
 
 Ockam enables attribute authentication using **cryptographically verifiable credentials.**
 
@@ -48,13 +48,13 @@ Once we have authenticated attributes, a resource owner can make trust decisions
 
 Any Ockam Identifier can issue credentials about another Identifier, however some credential authorities are central to the success and scale of a distributed application. For such authorities Ockam Orchestrator offers highly scalable and secure managed credential authorities as a cloud service.
 
-We also have to consider how credentials are issued to a large number of application entities. Ockam offers several pluggable enrollment protocols. Once simple option is to use one-time-use enrollment tokens. This is a great option to enroll large fleets of applications, service, or devices. It is also easy to use with automated provisioning scripts and tools.
+We also have to consider how credentials are issued to a large number of application entities. Ockam offers several pluggable enrollment protocols. Once simple option is to use one-time-use enrollment tokens. This is a great option to enroll large fleets of applications, services, or devices. It is also easy to use with automated provisioning scripts and tools.
 
 <figure><img src="../../.gitbook/assets/diagrams.003.jpeg" alt=""><figcaption><p>Please click the diagram to see a bigger version.</p></figcaption></figure>
 
 ### Okta Add-On for Ockam Orchestrator
 
-For most enterprises, workforce identities are already defined in enterprise identity systems like Okta. Ockam Orchestrator offers an Okta Add-On that uses OIDC to allows enterprise employees to get Ockam credentials using their regular corporate login.
+For most enterprises, workforce identities are already defined in enterprise identity systems like Okta. Ockam Orchestrator offers an Okta Add-On that uses OIDC to allow enterprise employees to get Ockam credentials using their regular corporate login.
 
 Their user profile information like department, city, team etc. is included in the credential and securely attested by the Credential Authority.
 
@@ -64,13 +64,13 @@ This combination is incredibly powerful. It allows **employees to get just-in-ti
 
 ## Step-by-Step Walkthrough
 
-Let's walkthrough a simple example of Okta + Ockam in action.
+Let's walk through a simple example of Okta + Ockam in action.
 
-We have a distributed application which has micro-service components running in San Francisco and New York. These components have Ockam Identities and Credentials and communicating trustfully using Ockam Secure Channels.
+We have a distributed application which has microservice components running in San Francisco and New York. These components have Ockam Identities and Credentials and communicate trustfully using Ockam Secure Channels.
 
-There is a problem in one of the micro-services in San Francisco and we need to give Alice (an engineer from San Francisco) secure, short lived, revocable access to just that service and nothing more.
+There is a problem in one of the microservices in San Francisco and we need to give Alice (an engineer from San Francisco) secure, short lived, revocable access to just that service and nothing more.
 
-First we'll create our application components and then see how to give access to the Alice.
+First we'll create our application components and then see how to give access to Alice.
 
 ### Setup
 
@@ -118,7 +118,7 @@ We'll represent the application service on Machine 1 with a simple http server l
 python3 -m http.server --bind 127.0.0.1 5000
 ```
 
-Next we transfer project configuration and one enrollment token to Machine 1 and use that to create and Ockam node that will run as a sidecar process next to our application service.
+Next we transfer project configuration and one enrollment token to Machine 1 and use that to create an Ockam node that will run as a sidecar process next to our application service.
 
 ```bash
 ockam identity create m1
@@ -130,7 +130,7 @@ ockam tcp-outlet create --at /node/m1 --from /service/outlet --to 127.0.0.1:5000
 ockam relay create m1 --at /project/default --to /node/m1
 ```
 
-We then set an attribute based policy on the the tcp-outlet that delivers traffic to our application service. This policy says to allow requests if the subject (the entity requesting access) is part of the same application or if the subject is a Field Engineer based in San Francisco.
+We then set an attribute based policy on the tcp-outlet that delivers traffic to our application service. This policy says to allow requests if the subject (the entity requesting access) is part of the same application or if the subject is a Field Engineer based in San Francisco.
 
 ```
 (or (= subject.application "Smart Factory")
@@ -168,9 +168,9 @@ Same as before, we then set an attribute based policy on the the tcp-outlet that
 
 ### Engineer for San Francisco
 
-There is a problem in one of the micro-services in San Francisco and we need to give Alice (an engineer from San Francisco) secure, short lived, revocable access to just that service and nothing more.
+There is a problem in one of the microservices in San Francisco and we need to give Alice (an engineer from San Francisco) secure, short lived, revocable access to just that service and nothing more.
 
-Since the Okta Add-On is enabled. Alice can simple start a node within the project and authenticate.
+Since the Okta Add-On is enabled. Alice can simply start a node within the project and authenticate.
 
 ```bash
 ockam project enroll --project-path project.json --okta
@@ -178,7 +178,7 @@ ockam node create alice
 ockam policy create --at alice --resource tcp-inlet --expression '(= subject.application "Smart Factory")'
 ```
 
-The `project enroll` command will launch Okta login and when it completes return a an Ockam cryptographic credential that includes the city and department attributes of Alice's profile in Okta Universal Directory. Only these two attributes are attested because the administrator specified those two attributes when enabling the Okta Add-On.
+The `project enroll` command will launch Okta login and when it completes return an Ockam cryptographic credential that includes the city and department attributes of Alice's profile in Okta Universal Directory. Only these two attributes are attested because the administrator specified those two attributes when enabling the Okta Add-On.
 
 <figure><img src="../../.gitbook/assets/200395627-827d672a-2140-4752-a8d5-526ec5f0be68.png" alt=""><figcaption><p>User Profile in Okta</p></figcaption></figure>
 
@@ -202,4 +202,4 @@ curl --head 127.0.0.1:9000
 
 When new employees join the Field Engineering team in San Francisco, they will get an Okta workforce identity and can also request access to services they are responsible for in San Francisco without any change to the system.
 
-These attribute based policies can easily span the spectrum of very simple to be highly fine-grained and dynamic depending on the needs of an application. At the same time, this approach is highly scalable because it decouples enterprise identity administration form an application's trust policies.
+These attribute based policies can easily span the spectrum of very simple to be highly fine-grained and dynamic depending on the needs of an application. At the same time, this approach is highly scalable because it decouples enterprise identity administration from an application's trust policies.


### PR DESCRIPTION
Read through Okta example and noticed some typos and inconsistencies