### PR TITLE
style: add css for preview tag

### DIFF
--- a/manual/template/mdbook/book.toml
+++ b/manual/template/mdbook/book.toml
@@ -8,6 +8,7 @@ title = "Ockam Command Manual"
 [output.html]
 default-theme = "rust"
 preferred-dark-theme = "navy"
+additional-css = ["custom.css"]
 
 [output.html.fold]
 enable = true

--- a/manual/template/mdbook/custom.css
+++ b/manual/template/mdbook/custom.css
@@ -1,0 +1,52 @@
+.chip {
+    display: inline-block;
+    padding: 0 10px;
+    height: 32px;
+    font-size: 1.4rem;
+    line-height: 32px;
+    border-radius: 3px;
+    background-color: #f6f7f6;
+    vertical-align: top;
+}
+
+/* Tooltips */
+
+.t {
+    position: relative;
+    display: inline-block;
+}
+
+.t .tt {
+    visibility: hidden;
+    font-size: 0.8em;
+    line-height: 1.5em;
+    width: 450px;
+    background-color: #555;
+    color: #fff;
+    padding: 5px 10px;
+    border-radius: 6px;
+    position: absolute;
+    z-index: 1;
+}
+
+.t:hover .tt {
+    visibility: visible;
+}
+
+.tt {
+    top: 135%;
+    left: 50%;
+    margin-left: -60px;
+}
+
+.tt::after {
+    content: "";
+    position: absolute;
+    bottom: 100%;
+    left: 13%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent transparent #555 transparent;
+}
+


### PR DESCRIPTION
The background color is the same as the code blocks'. Maybe we could tweak a little the font.

![image](https://github.com/build-trust/ockam-documentation/assets/12375782/0dce859f-4d93-4dab-9f60-c6a474703e17)

In the terminal will look like:

![image](https://github.com/build-trust/ockam-documentation/assets/12375782/b3752338-2652-4baf-be85-1e81573c29cd)