### PR TITLE
Refactor two use cases: ABAC, Okta

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -21,6 +21,8 @@
   * [Telegraf + InfluxDB](guides/examples/telegraf-+-influxdb.md)
   * [InfluxDB Cloud token lease management](guides/examples/influxdb-cloud-token-lease-management.md)
   * [End-to-end encryption through Kafka](guides/examples/end-to-end-encrypted-kafka.md)
+  * [Attribute-Based Access Control (ABAC)](guides/examples/abac.md)
+  * [Use employee attributes from Okta](guides/examples/okta.md)
 
 ## Reference
 

--- a/guides/examples/abac.md
+++ b/guides/examples/abac.md
@@ -1,0 +1,206 @@
+# Apply fine-grained permissions with Attribute-Based Access Control (ABAC)
+
+Attribute-Based Access Control (ABAC) is an authorization strategy that grants or denies access
+based on attributes.
+
+A subject’s request to perform an operation on a resource is granted or denied based on attributes
+of the **subject**, attributes of the **operation**, attributes of the **resource**, and attributes
+of the **environment**. Access is controlled using **policies** that are defined in terms of those
+attributes.
+
+In this guide we’ll walk through a step-by-step demo of using Ockam to add policy driven,
+attribute-based access control to any application using cryptographically verifiable
+credentials.
+
+## Background
+
+Modern applications are distributed and have an unwieldy number of interconnections that must
+trustfully exchange data and instructions.
+
+In order to trust information or instructions, that are received over the network, applications must
+**authenticate** all senders and **verify the integrity of data** **received** to assert what was
+received is exactly what was sent — free from errors or en-route tampering.
+
+Applications must also decide if a sender of a request is **authorized** to trigger the requested
+action or view the requested data.
+
+In scenarios where human users are authenticating with cloud services, we have some mature protocols
+like OAuth 2.0 and OpenID Connect (OIDC) that help tackle parts of the problem. However, majority of
+data that flows within modern applications doesn’t involve humans. Microservices interact with other
+microservices, devices interact with other devices and cloud services, internal services interact
+with partner systems and infrastructure services etc.
+
+**Secure** **by-design** applications must ensure that all machine-to-machine application layer
+communication is authenticated and authorized. For this, **applications must prove identifiers and
+attributes.**
+
+### Cryptographically Provable Identifiers
+
+Ockam makes it simple to safely generate unique **cryptographically provable identifiers** and store
+their private keys in safe vaults. Ockam Secure Channels enable **mutual authentication** using
+these cryptographically provable identifiers.
+
+On this foundation of mutually authenticated secure channels that guarantee end-to-end data
+authenticity, integrity and confidentiality, we give you tools to make fine-grained trust and
+authorization decisions.
+
+One simple model of trust and authorization that is possible using only cryptographically provable
+identifiers is Access Control Lists (ACLs). A resource server is given a list of identifiers that it
+will allow access to a resource through an authenticated channel. This works great for simple
+scenarios but is hard to scale. As new clients or users need access to this resource, the access
+control list has to updated.
+
+A much more powerful and scalable model becomes feasible with cryptographically provable
+credentials.
+
+### Authenticated Attributes and Cryptographic Credentials
+
+When making fine-grained trust and access control decisions, applications often need to reason about
+the properties or attributes of an entity that is requesting access to a resource or reporting some
+data. For example, an application may require that its inventory microservice is the only service
+that is allowed to report the current status of inventory. For this to work, applications need to a
+way to authenticate attributes.
+
+Ockam enables attribute authentication using **cryptographically verifiable credentials.**
+
+A credential **Verifier** trusts the public identifier of a credential **Authority**. A **Prover**
+that wishes to authenticate an attribute to this verifier gets a cryptographically signed credential
+from this same credential authority. By issuing a credential, the authority attests to one or more
+attributes of the prover. For example the authority may attest that a particular identifier has the
+attributes `service-type=inventory, location="New York".
+
+Credentials are issued over mutually authenticated, end-to-end secure channels and carry a
+cryptographic signature over an authenticated identifier and its attributes. This then allows a
+verifier to check signatures and authenticate attributes.
+
+Once we have authenticated attributes, a resource owner can make trust decisions based on these
+attributes rooted in attestations by trusted authorities.
+
+<figure><img src="../../.gitbook/assets/diagrams.004.jpeg" alt=""><figcaption><p>Please click the diagram to see a bigger version.</p></figcaption></figure>
+
+### Credential Authorities and Enrollment Protocols
+
+Any Ockam Identifier can issue credentials about another Identifier, however some credential
+authorities are central to the success and scale of a distributed application. For such authorities
+Ockam Orchestrator offers highly scalable and secure managed credential authorities as a cloud
+service.
+
+We also have to consider how credentials are issued to a large number of application entities. Ockam
+offers several pluggable enrollment protocols. Once simple option is to use one-time-use enrollment
+tokens. This is a great option to enroll large fleets of applications, service, or devices. It is
+also easy to use with automated provisioning scripts and tools.
+
+<figure><img src="../../.gitbook/assets/diagrams.003.jpeg" alt=""><figcaption><p>Please click the diagram to see a bigger version.</p></figcaption></figure>
+
+## Step-by-Step Walkthrough
+
+### Install Ockam Command
+
+Ockam Command is our Command Line Interface (CLI) for interfacing with Ockam processes.
+
+{% tabs %} {% tab title="Homebrew" %} If you use Homebrew, you can install Ockam using brew:
+
+```
+brew install build-trust/ockam/ockam
+```
+
+{% endtab %}
+
+{% tab title="Other Systems" %}
+
+```shell
+ curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/build-trust/ockam/develop/install.sh | sh
+```
+
+After the binary downloads, please move it to a location in your shell's `$PATH`, like
+`/usr/local/bin`. {% endtab %} {% endtabs %}
+
+### Administrator
+
+```bash
+# Check that everything was installed by enrolling with Ockam Orchestrator.
+#
+# This will provision an End-to-End Encrypted Cloud Relay service for you in
+# your `default` project at `/project/default`.
+ockam enroll
+```
+
+```bash
+# Creates enrollment tokens for the three types of identities that
+# will be created and used within this example
+cp1_token=$(ockam project ticket --attribute component=control)
+ep1_token=$(ockam project ticket --attribute component=edge)
+x_token=$(ockam project ticket --attribute component=x)
+```
+
+### Control Plane
+
+```bash
+# In a separate terminal window:
+# Start an application service, listening on a local ip and port, that clients
+# would access through the cloud encrypted relay. We'll use a simple http server
+# for this first example but this could be any other application service.
+python3 -m http.server --bind 127.0.0.1 5000
+```
+
+```bash
+# Create an identity and authenticate the identity for this control plane
+# with the Orchestrator project.
+ockam identity create control_identity
+ockam project enroll $cp1_token --identity control_identity
+
+# Create a node targeting the project as the control identity.
+ockam node create control_plane1 --identity control_identity
+
+# Set a policy, create the tcp-outlet and forwarder.
+ockam policy create --at control_plane1 --resource tcp-outlet --expression '(= subject.component "edge")'
+ockam tcp-outlet create --at /node/control_plane1 --from /service/outlet --to 127.0.0.1:5000
+ockam relay create control_plane1 --at /project/default --to /node/control_plane1
+```
+
+### Edge Plane
+
+```bash
+# Create an identity and authenticate the identity for this edge plane
+# with the Orchestrator project.
+ockam identity create edge_identity
+ockam project enroll $ep1_token --identity edge_identity
+
+# Create a node targeting the project as the edge identity.
+ockam node create edge_plane1 --identity edge_identity
+
+# Set a policy, and create the tcp-inlet.
+ockam policy create --at edge_plane1 --resource tcp-inlet --expression '(= subject.component "control")'
+ockam tcp-inlet create --at /node/edge_plane1 --from 127.0.0.1:7000 --to /project/default/service/forward_to_control_plane1/secure/api/service/outlet
+```
+
+```bash
+# Send a request to our tcp-inlet at the `edge_plane1` node.
+#
+# This request will successfully be forwarded through the Ockam Orchestrator
+# project to the `control_plane1` node and out to the python server
+# all with full end-to-end encryption and Attribute-Based Access Control.
+curl --fail --head --max-time 10 127.0.0.1:7000
+```
+
+The following is denied:
+
+```bash
+# Create an identity and authenticate the identity for this x node
+# with the Orchestrator project.
+#
+# This identity will use the enrollment token that has the attribute of
+# `component=x` attached
+ockam identity create x_identity
+ockam project enroll $x_token --identity x_identity
+
+# Create a node targeting the project as the x identity.
+ockam node create x --identity x_identity
+
+# Set a policy and create a new tcp-inlet for node x.
+ockam policy create --at x --resource tcp-inlet --expression '(= subject.component "control")'
+ockam tcp-inlet create --at /node/x --from 127.0.0.1:8000 --to /project/default/service/forward_to_control_plane1/secure/api/service/outlet
+
+# Sends a request to our `x` tcp-inlet and will be denied (this will timeout)
+curl --fail --head --max-time 5 127.0.0.1:8000
+```

--- a/guides/examples/okta.md
+++ b/guides/examples/okta.md
@@ -1,0 +1,208 @@
+# Use employee attributes from Okta to Build Trust with Cryptographically Verifiable Credentials
+
+In this guide, we’ll step through a demo of how workforce identities in Okta can be combined with application identities in Ockam to bring policy driven, attribute-based access control of distributed applications – using cryptographically verifiable credentials.
+
+<figure><img src="../../.gitbook/assets/diagrams.003 (1).jpeg" alt=""><figcaption><p>Please click the diagram to see a bigger version.</p></figcaption></figure>
+
+## Background
+
+Modern applications are distributed and have an unwieldy number of interconnections that must trustfully exchange data and instructions.
+
+In order to trust information or instructions, that are received over the network, applications must **authenticate** all senders and **verify the integrity of data** **received** to assert what was received is exactly what was sent — free from errors or en-route tampering.
+
+Applications must also decide if a sender of a request is **authorized** to trigger the requested action or view the requested data.
+
+In scenarios where human users are authenticating with cloud services, we have some mature protocols like OAuth 2.0 and OpenID Connect (OIDC) that help tackle parts of the problem. However, the majority of data that flows within modern applications doesn’t involve humans. Microservices interact with other microservices, devices interact with other devices and cloud services, internal services interact with partner systems and infrastructure services etc.
+
+**Secure** **by-design** applications must ensure that all machine-to-machine application layer communication is authenticated and authorized. For this, **applications must prove identifiers and attributes.**
+
+### Cryptographically Provable Identifiers
+
+Ockam makes it simple to safely generate unique **cryptographically provable identifiers** and store their private keys in safe vaults. Ockam Secure Channels enable **mutual authentication** using these cryptographically provable identifiers.
+
+On this foundation of mutually authenticated secure channels that guarantee end-to-end data authenticity, integrity and confidentiality, we give you tools to make fine-grained trust and authorization decisions.
+
+One simple model of trust and authorization that is possible using only cryptographically provable identifiers is Access Control Lists (ACLs). A resource server is given a list of identifiers that it will allow access to a resource through an authenticated channel. This works great for simple scenarios but is hard to scale. As new clients or users need access to this resource, the access control list has to be updated.
+
+A much more powerful and scalable model becomes feasible with cryptographically provable credentials.
+
+### Authenticated Attributes and Cryptographic Credentials
+
+When making fine-grained trust and access control decisions, applications often need to reason about the properties or attributes of an entity that is requesting access to a resource or reporting some data. For example, an application may require that its inventory microservice is the only service that is allowed to report the current status of inventory. For this to work, applications need a way to authenticate attributes.
+
+Ockam enables attribute authentication using **cryptographically verifiable credentials.**
+
+A credential **Verifier** trusts the public identifier of a credential **Authority**. A **Prover** that wishes to authenticate an attribute to this verifier gets a cryptographically signed credential from this same credential authority. By issuing a credential, the authority attests to one or more attributes of the prover. For example the authority may attest that a particular identifier has the attributes `service-type=inventory, location="New York"`.
+
+Credentials are issued over mutually authenticated, end-to-end secure channels and carry a cryptographic signature over an authenticated identifier and its attributes. This then allows a verifier to check signatures and authenticate attributes.
+
+Once we have authenticated attributes, a resource owner can make trust decisions based on these attributes rooted in attestations by trusted authorities.
+
+<figure><img src="../../.gitbook/assets/diagrams.004.jpeg" alt=""><figcaption><p>Please click the diagram to see a bigger version.</p></figcaption></figure>
+
+### Credential Authorities and Enrollment Protocols
+
+Any Ockam Identifier can issue credentials about another Identifier, however some credential authorities are central to the success and scale of a distributed application. For such authorities Ockam Orchestrator offers highly scalable and secure managed credential authorities as a cloud service.
+
+We also have to consider how credentials are issued to a large number of application entities. Ockam offers several pluggable enrollment protocols. Once simple option is to use one-time-use enrollment tokens. This is a great option to enroll large fleets of applications, services, or devices. It is also easy to use with automated provisioning scripts and tools.
+
+<figure><img src="../../.gitbook/assets/diagrams.003.jpeg" alt=""><figcaption><p>Please click the diagram to see a bigger version.</p></figcaption></figure>
+
+### Okta Add-On for Ockam Orchestrator
+
+For most enterprises, workforce identities are already defined in enterprise identity systems like Okta. Ockam Orchestrator offers an Okta Add-On that uses OIDC to allow enterprise employees to get Ockam credentials using their regular corporate login.
+
+Their user profile information like department, city, team etc. is included in the credential and securely attested by the Credential Authority.
+
+This combination is incredibly powerful. It allows **employees to get just-in-time, short lived, fine-grained revocable credentials to only the application components that they need to access.** It eliminates long lived static keys and credentials from being stored on work machines.
+
+<figure><img src="../../.gitbook/assets/diagrams.003 (1).jpeg" alt=""><figcaption><p>Please click the diagram to see a bigger version.</p></figcaption></figure>
+
+## Step-by-Step Walkthrough
+
+Let's walk through a simple example of Okta + Ockam in action.
+
+We have a distributed application which has microservice components running in San Francisco and New York. These components have Ockam Identities and Credentials and communicate trustfully using Ockam Secure Channels.
+
+There is a problem in one of the microservices in San Francisco and we need to give Alice (an engineer from San Francisco) secure, short lived, revocable access to just that service and nothing more.
+
+First we'll create our application components and then see how to give access to Alice.
+
+### Required Dependencies
+
+Through this example `https://trial-9434859.okta.com/oauth2/default`  refers to an existing okta endpoint where workforce identities are defined.  The okta user profile is expected to contain `email`, `city` and `department` attributes.  These attributes will be included on the generated okcam credentials.
+
+If you don't have an okta install already, you can create a [trial one](https://www.okta.com/free-trial/) to follow this example use case.
+
+
+### Setup
+
+If you use Homebrew, you can install Ockam using `brew`.
+
+```bash
+brew install build-trust/ockam/ockam
+```
+
+Otherwise, you can download our latest architecture specific pre-compiled binary by running:
+
+```shell
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/build-trust/ockam/develop/install.sh | sh
+```
+
+After the binary downloads, please move it to a location in your shell's `$PATH`, like `/usr/local/bin`.
+
+### Administrator
+
+Next we provision our system. We enroll with Ockam Orchestrator, enable the Okta Add-On and export the project configuration to share with Alice.
+
+```bash
+ockam enroll
+ockam project addon configure okta \
+  --tenant https://trial-9434859.okta.com/oauth2/default --client-id 0oa2pi8no6Kb04frP697 \
+  --attribute email --attribute city --attribute department
+
+ockam project information --output json > project.json
+```
+
+This will create a managed Credential Authority for our project.
+
+Next we generate two one-time-use enrollment tokens to enable Machine 1 and 2 to enroll and get credentials. Notice how we specify the attributes to attest for these two machines - `city` and `application`
+
+```
+m1_token=$(ockam project ticket --attribute application="Smart Factory" --attribute city="San Francisco")
+m2_token=$(ockam project ticket --attribute application="Smart Factory" --attribute city="New York")
+```
+
+### Machine 1 in New York
+
+We'll represent the application service on Machine 1 with a simple http server listening on port `5000` but this could be any application service:
+
+```
+python3 -m http.server --bind 127.0.0.1 5000
+```
+
+Next we transfer project configuration and one enrollment token to Machine 1 and use that to create an Ockam node that will run as a sidecar process next to our application service.
+
+```bash
+ockam identity create m1
+ockam project enroll $m1_token --identity m1
+ockam node create m1 --identity m1
+ockam policy create --at m1 --resource tcp-outlet \
+  --expression '(or (= subject.application "Smart Factory") (and (= subject.department "Field Engineering") (= subject.city "San Francisco")))'
+ockam tcp-outlet create --at /node/m1 --from /service/outlet --to 127.0.0.1:5000
+ockam relay create m1 --at /project/default --to /node/m1
+```
+
+We then set an attribute based policy on the tcp-outlet that delivers traffic to our application service. This policy says to allow requests if the subject (the entity requesting access) is part of the same application or if the subject is a Field Engineer based in San Francisco.
+
+```
+(or (= subject.application "Smart Factory")
+    (and (= subject.department "Field Engineering") (= subject.city "San Francisco")))
+```
+
+The first part of the policy allows various application component services to communicate with each other. The second part is what will enable Alice. However, note that there is no mention of Alice here, only a department and a city.
+
+### Machine 2 in San Francisco
+
+We'll represent the application service on Machine 2 with a simple http server listening on port 6`000` but this could be any application service:
+
+```
+python3 -m http.server --bind 127.0.0.1 6000
+```
+
+Next we transfer project configuration and one enrollment token to Machine 2 and use that to create and Ockam node that will run as a sidecar process next to our application service.
+
+```bash
+ockam identity create m2
+ockam project enroll $m2_token --identity m2
+ockam node create m2 --identity m2
+ockam policy create --at m2 --resource tcp-outlet \
+  --expression '(or (= subject.application "Smart Factory") (and (= subject.department "Field Engineering") (= subject.city "New York")))'
+ockam tcp-outlet create --at /node/m2 --from /service/outlet --to 127.0.0.1:6000
+ockam relay create m2 --at /project/default --to /node/m2
+```
+
+Same as before, we then set an attribute based policy on the the tcp-outlet that delivers traffic to our application service. This policy says to allow requests if the subject (the entity requesting access) is part of the same application or if the subject is a Field Engineer based in New York.
+
+```
+(or (= subject.application "Smart Factory")
+    (and (= subject.department "Field Engineering") (= subject.city "New York")))
+```
+
+### Engineer for San Francisco
+
+There is a problem in one of the microservices in San Francisco and we need to give Alice (an engineer from San Francisco) secure, short lived, revocable access to just that service and nothing more.
+
+Since the Okta Add-On is enabled. Alice can simply start a node within the project and authenticate.
+
+```bash
+ockam project enroll --project-path project.json --okta
+ockam node create alice
+ockam policy create --at alice --resource tcp-inlet --expression '(= subject.application "Smart Factory")'
+```
+
+The `project enroll` command will launch Okta login and when it completes return an Ockam cryptographic credential that includes the city and department attributes of Alice's profile in Okta Universal Directory. Only these two attributes are attested because the administrator specified those two attributes when enabling the Okta Add-On.
+
+<figure><img src="../../.gitbook/assets/200395627-827d672a-2140-4752-a8d5-526ec5f0be68.png" alt=""><figcaption><p>User Profile in Okta</p></figcaption></figure>
+
+Alice's `city` in Okta is "San Francisco". Her request to access Machine 1 in San Francisco is allowed
+
+```
+ockam tcp-inlet create --at /node/alice --from 127.0.0.1:8000 \
+  --to /project/default/service/forward_to_m1/secure/api/service/outlet
+curl --head 127.0.0.1:8000
+```
+
+Her request to access Machine 2 in New York is denied.
+
+```
+ockam tcp-inlet create --at /node/alice --from 127.0.0.1:9000 \
+  --to /project/default/service/forward_to_m2/secure/api/service/outlet
+curl --head 127.0.0.1:9000
+
+# this will do nothing and eventually timeout
+```
+
+When new employees join the Field Engineering team in San Francisco, they will get an Okta workforce identity and can also request access to services they are responsible for in San Francisco without any change to the system.
+
+These attribute based policies can easily span the spectrum of very simple to be highly fine-grained and dynamic depending on the needs of an application. At the same time, this approach is highly scalable because it decouples enterprise identity administration from an application's trust policies.

--- a/guides/use-cases/apply-fine-grained-permissions-with-attribute-based-access-control-abac.md
+++ b/guides/use-cases/apply-fine-grained-permissions-with-attribute-based-access-control-abac.md
@@ -1,165 +1,60 @@
+---
+description: >-
+  Secure by-design applications ensure that all machine-to-machine application layer communication
+  is authenticated and authorized
+---
+
 # Apply fine-grained permissions with Attribute-Based Access Control (ABAC)
 
-Attribute-Based Access Control (ABAC) is an authorization strategy that grants or denies access based on attributes.
+Modern applications are distributed and have an unwieldy number of interconnections that must
+trustfully exchange data and instructions.
 
-A subject’s request to perform an operation on a resource is granted or denied based on attributes of the **subject**, attributes of the **operation**, attributes of the **resource**, and attributes of the **environment**. Access is controlled using **policies** that are defined in terms of those attributes.
+Authentication is a process where one entity gains assurances about the attributes of another
+entity. In other words, it is a process of proving that you are who you say you are.
 
-In this guide we’ll walk through a step-by-step [<mark style="color:blue;">demo</mark>](apply-fine-grained-permissions-with-attribute-based-access-control-abac.md#step-by-step-walkthrough) of using Ockam to add policy driven, attribute-based access control to any application using cryptographically verifiable credentials.
+Authorization is the process of deciding if a request to access a resource should be granted. In
+other words, it is a process that grants you the permission to do the "thing" that you are
+attempting to do.
 
-## Background
+### The problem
 
-Modern applications are distributed and have an unwieldy number of interconnections that must trustfully exchange data and instructions.
+In order to trust information or instructions, that are received over the network, applications must
+**authenticate** all senders and **verify the integrity of data** **received** to assert what was
+received is exactly what was sent — free from errors or en-route tampering.
 
-In order to trust information or instructions, that are received over the network, applications must **authenticate** all senders and **verify the integrity of data** **received** to assert what was received is exactly what was sent — free from errors or en-route tampering.
+Applications must also decide if a sender of a request is **authorized** to trigger the requested
+action or view the requested data.
 
-Applications must also decide if a sender of a request is **authorized** to trigger the requested action or view the requested data.
+In scenarios where human users are authenticating with cloud services, we have some mature protocols
+like OAuth 2.0 and OpenID Connect (OIDC) that help tackle parts of the problem.
 
-In scenarios where human users are authenticating with cloud services, we have some mature protocols like OAuth 2.0 and OpenID Connect (OIDC) that help tackle parts of the problem. However, majority of data that flows within modern applications doesn’t involve humans. Microservices interact with other microservices, devices interact with other devices and cloud services, internal services interact with partner systems and infrastructure services etc.
+However, majority of data that flows within modern applications doesn’t involve humans.
+Microservices interact with other microservices, devices interact with other devices and cloud
+services, internal services interact with partner systems and infrastructure services etc.
 
-**Secure** **by-design** applications must ensure that all machine-to-machine application layer communication is authenticated and authorized. For this, **applications must prove identifiers and attributes.**
+**Secure** **by-design** applications must ensure that all machine-to-machine application layer
+communication is authenticated and authorized. For this, **applications must prove identifiers and
+attributes.**
 
-### Cryptographically Provable Identifiers
+### How Ockam simplifies it
 
-Ockam makes it simple to safely generate unique **cryptographically provable identifiers** and store their private keys in safe vaults. Ockam Secure Channels enable **mutual authentication** using these cryptographically provable identifiers.
+Attribute-Based Access Control (ABAC) is an authorization strategy that grants or denies access
+based on attributes.
 
-On this foundation of mutually authenticated secure channels that guarantee end-to-end data authenticity, integrity and confidentiality, we give you tools to make fine-grained trust and authorization decisions.
+A subject’s request to perform an operation on a resource is granted or denied based on attributes
+of the **subject**, attributes of the **operation**, attributes of the **resource**, and attributes
+of the **environment**. Access is controlled using **policies** that are defined in terms of those
+attributes.
 
-One simple model of trust and authorization that is possible using only cryptographically provable identifiers is Access Control Lists (ACLs). A resource server is given a list of identifiers that it will allow access to a resource through an authenticated channel. This works great for simple scenarios but is hard to scale. As new clients or users need access to this resource, the access control list has to updated.
+### Next steps
 
-A much more powerful and scalable model becomes feasible with cryptographically provable credentials.
-
-### Authenticated Attributes and Cryptographic Credentials
-
-When making fine-grained trust and access control decisions, applications often need to reason about the properties or attributes of an entity that is requesting access to a resource or reporting some data. For example, an application may require that its inventory microservice is the only service that is allowed to report the current status of inventory. For this to work, applications need to a way to authenticate attributes.
-
-Ockam enables attribute authentication using **cryptographically verifiable credentials.**
-
-A credential **Verifier** trusts the public identifier of a credential **Authority**. A **Prover** that wishes to authenticate an attribute to this verifier gets a cryptographically signed credential from this same credential authority. By issuing a credential, the authority attests to one or more attributes of the prover. For example the authority may attest that a particular identifier has the attributes `service-type=inventory, location="New York"`  &#x20;
-
-Credentials are issued over mutually authenticated, end-to-end secure channels and carry a cryptographic signature over an authenticated identifier and its attributes. This then allows a verifier to check signatures and authenticate attributes.
-
-Once we have authenticated attributes, a resource owner can make trust decisions based on these attributes rooted in attestations by trusted authorities.
-
-<figure><img src="../../.gitbook/assets/diagrams.004.jpeg" alt=""><figcaption><p>Please click the diagram to see a bigger version.</p></figcaption></figure>
-
-### Credential Authorities and Enrollment Protocols
-
-Any Ockam Identifier can issue credentials about another Identifier, however some credential authorities are central to the success and scale of a distributed application. For such authorities Ockam Orchestrator offers highly scalable and secure managed credential authorities as a cloud service.
-
-We also have to consider how credentials are issued to a large number of application entities. Ockam offers several pluggable enrollment protocols. Once simple option is to use one-time-use enrollment tokens. This is a great option to enroll large fleets of applications, service, or devices. It is also easy to use with automated provisioning scripts and tools.
-
-<figure><img src="../../.gitbook/assets/diagrams.003.jpeg" alt=""><figcaption><p>Please click the diagram to see a bigger version.</p></figcaption></figure>
-
-## Step-by-Step Walkthrough
-
-### Install Ockam Command
-
-Ockam Command is our Command Line Interface (CLI) for interfacing with Ockam processes.&#x20;
-
-{% tabs %}
-{% tab title="Homebrew" %}
-If you use Homebrew, you can install Ockam using brew:
-
-```
-brew install build-trust/ockam/ockam
-```
-{% endtab %}
-
-{% tab title="Other Systems" %}
-```shell
- curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/build-trust/ockam/develop/install.sh | sh
-```
-
-After the binary downloads, please move it to a location in your shell's `$PATH`, like `/usr/local/bin`.
-{% endtab %}
-{% endtabs %}
-
-### Administrator
-
-```bash
-# Check that everything was installed by enrolling with Ockam Orchestrator.
-#
-# This will provision an End-to-End Encrypted Cloud Relay service for you in
-# your `default` project at `/project/default`.
-ockam enroll
-```
-
-```bash
-# Creates enrollment tokens for the three types of identities that
-# will be created and used within this example
-cp1_token=$(ockam project ticket --attribute component=control)
-ep1_token=$(ockam project ticket --attribute component=edge)
-x_token=$(ockam project ticket --attribute component=x)
-```
-
-### Control Plane
-
-```bash
-# In a separate terminal window:
-# Start an application service, listening on a local ip and port, that clients
-# would access through the cloud encrypted relay. We'll use a simple http server
-# for this first example but this could be any other application service.
-python3 -m http.server --bind 127.0.0.1 5000
-```
-
-```bash
-# Create an identity and authenticate the identity for this control plane
-# with the Orchestrator project.
-ockam identity create control_identity
-ockam project enroll $cp1_token --identity control_identity
-
-# Create a node targeting the project as the control identity.
-ockam node create control_plane1 --identity control_identity
-
-# Set a policy, create the tcp-outlet and forwarder.
-ockam policy create --at control_plane1 --resource tcp-outlet --expression '(= subject.component "edge")'
-ockam tcp-outlet create --at /node/control_plane1 --from /service/outlet --to 127.0.0.1:5000
-ockam relay create control_plane1 --at /project/default --to /node/control_plane1
-```
-
-### Edge Plane
-
-```bash
-# Create an identity and authenticate the identity for this edge plane
-# with the Orchestrator project.
-ockam identity create edge_identity
-ockam project enroll $ep1_token --identity edge_identity
-
-# Create a node targeting the project as the edge identity.
-ockam node create edge_plane1 --identity edge_identity
-
-# Set a policy, and create the tcp-inlet.
-ockam policy create --at edge_plane1 --resource tcp-inlet --expression '(= subject.component "control")'
-ockam tcp-inlet create --at /node/edge_plane1 --from 127.0.0.1:7000 --to /project/default/service/forward_to_control_plane1/secure/api/service/outlet
-```
-
-```bash
-# Send a request to our tcp-inlet at the `edge_plane1` node.
-#
-# This request will successfully be forwarded through the Ockam Orchestrator
-# project to the `control_plane1` node and out to the python server
-# all with full end-to-end encryption and Attribute-Based Access Control.
-curl --fail --head --max-time 10 127.0.0.1:7000
-```
-
-The following is denied:
-
-```bash
-# Create an identity and authenticate the identity for this x node
-# with the Orchestrator project.
-#
-# This identity will use the enrollment token that has the attribute of
-# `component=x` attached
-ockam identity create x_identity
-ockam project enroll $x_token --identity x_identity
-
-# Create a node targeting the project as the x identity.
-ockam node create x --identity x_identity
-
-# Set a policy and create a new tcp-inlet for node x.
-ockam policy create --at x --resource tcp-inlet --expression '(= subject.component "control")'
-ockam tcp-inlet create --at /node/x --from 127.0.0.1:8000 --to /project/default/service/forward_to_control_plane1/secure/api/service/outlet
-
-# Sends a request to our `x` tcp-inlet and will be denied (this will timeout)
-curl --fail --head --max-time 5 127.0.0.1:8000
-```
+- See an end-to-end example of this in our
+  [<mark style="color:blue;">ABAC demo</mark>](../examples/abac.md).
+- Follow our
+  [<mark style="color:blue;">getting started guide to install Ockam</mark>](../../reference/command/README.md#install)
+  and start using it in just a few minutes.
+- [<mark style="color:blue;">Reach out to the team</mark>](https://www.ockam.io/contact/form), we'd
+  love to talk to you in more detail about your potential use cases.
+- Join the growing community of developers who want to build trust by making applications that are
+  secure-by-design, in the
+  [<mark style="color:blue;">Build Trust Discord server</mark>](https://discord.gg/RAbjRr3kds).

--- a/guides/use-cases/use-employee-attributes-from-okta-to-build-trust-with-cryptographically-verifiable-credentials.md
+++ b/guides/use-cases/use-employee-attributes-from-okta-to-build-trust-with-cryptographically-verifiable-credentials.md
@@ -1,213 +1,75 @@
 ---
-description: Authenticate and authorize every access decision.
+description: Authenticate and authorize every access decision
 ---
 
 # Use employee attributes from Okta to Build Trust with Cryptographically Verifiable Credentials
 
-In this guide, we’ll step through a demo of how workforce identities in Okta can be combined with application identities in Ockam to bring policy driven, attribute-based access control of distributed applications – using cryptographically verifiable credentials.
+Modern applications are distributed and have an unwieldy number of interconnections that must
+trustfully exchange data and instructions.
+
+Authentication is a process where one entity gains assurances about the attributes of another
+entity. In other words, it is a process of proving that you are who you say you are.
+
+Authorization is the process of deciding if a request to access a resource should be granted. In
+other words, it is a process that grants you the permission to do the "thing" that you are
+attempting to do.
+
+### The problem
+
+In order to trust information or instructions, that are received over the network, applications must
+**authenticate** all senders and **verify the integrity of data** **received** to assert what was
+received is exactly what was sent — free from errors or en-route tampering.
+
+Applications must also decide if a sender of a request is **authorized** to trigger the requested
+action or view the requested data.
+
+In scenarios where human users are authenticating with cloud services, we have some mature protocols
+like OAuth 2.0 and OpenID Connect (OIDC) that help tackle parts of the problem.
+
+However, majority of data that flows within modern applications doesn’t involve humans.
+Microservices interact with other microservices, devices interact with other devices and cloud
+services, internal services interact with partner systems and infrastructure services etc.
+
+**Secure** **by-design** applications must ensure that all machine-to-machine application layer
+communication is authenticated and authorized. For this, **applications must prove identifiers and
+attributes.**
+
+### How Ockam simplifies it
+
+Ockam allows workforce identities in Okta to be combined with application identities in Ockam to
+bring policy driven, attribute-based access control of distributed applications – using
+cryptographically verifiable credentials.
 
 <figure><img src="../../.gitbook/assets/diagrams.003 (1).jpeg" alt=""><figcaption><p>Please click the diagram to see a bigger version.</p></figcaption></figure>
 
-## Background
+A subject’s request to perform an operation on a resource is granted or denied based on attributes
+of the **subject**, attributes of the **operation**, attributes of the **resource**, and attributes
+of the **environment**. Access is controlled using **policies** that are defined in terms of those
+attributes.
 
-Modern applications are distributed and have an unwieldy number of interconnections that must trustfully exchange data and instructions.
+For most enterprises, workforce identities are already defined in enterprise identity systems like
+Okta. Ockam Orchestrator offers an Okta Add-On that uses OIDC to allow enterprise employees to get
+Ockam credentials using their regular corporate login.
 
-In order to trust information or instructions, that are received over the network, applications must **authenticate** all senders and **verify the integrity of data** **received** to assert what was received is exactly what was sent — free from errors or en-route tampering.
+Their user profile information like department, city, team etc. is included in the credential and
+securely attested by the Credential Authority.
 
-Applications must also decide if a sender of a request is **authorized** to trigger the requested action or view the requested data.
-
-In scenarios where human users are authenticating with cloud services, we have some mature protocols like OAuth 2.0 and OpenID Connect (OIDC) that help tackle parts of the problem. However, the majority of data that flows within modern applications doesn’t involve humans. Microservices interact with other microservices, devices interact with other devices and cloud services, internal services interact with partner systems and infrastructure services etc.
-
-**Secure** **by-design** applications must ensure that all machine-to-machine application layer communication is authenticated and authorized. For this, **applications must prove identifiers and attributes.**
-
-### Cryptographically Provable Identifiers
-
-Ockam makes it simple to safely generate unique **cryptographically provable identifiers** and store their private keys in safe vaults. Ockam Secure Channels enable **mutual authentication** using these cryptographically provable identifiers.
-
-On this foundation of mutually authenticated secure channels that guarantee end-to-end data authenticity, integrity and confidentiality, we give you tools to make fine-grained trust and authorization decisions.
-
-One simple model of trust and authorization that is possible using only cryptographically provable identifiers is Access Control Lists (ACLs). A resource server is given a list of identifiers that it will allow access to a resource through an authenticated channel. This works great for simple scenarios but is hard to scale. As new clients or users need access to this resource, the access control list has to be updated.
-
-A much more powerful and scalable model becomes feasible with cryptographically provable credentials
-
-### Authenticated Attributes and Cryptographic Credentials
-
-When making fine-grained trust and access control decisions, applications often need to reason about the properties or attributes of an entity that is requesting access to a resource or reporting some data. For example, an application may require that its inventory microservice is the only service that is allowed to report the current status of inventory. For this to work, applications need a way to authenticate attributes.
-
-Ockam enables attribute authentication using **cryptographically verifiable credentials.**
-
-A credential **Verifier** trusts the public identifier of a credential **Authority**. A **Prover** that wishes to authenticate an attribute to this verifier gets a cryptographically signed credential from this same credential authority. By issuing a credential, the authority attests to one or more attributes of the prover. For example the authority may attest that a particular identifier has the attributes `service-type=inventory, location="New York"` .
-
-Credentials are issued over mutually authenticated, end-to-end secure channels and carry a cryptographic signature over an authenticated identifier and its attributes. This then allows a verifier to check signatures and authenticate attributes.
-
-Once we have authenticated attributes, a resource owner can make trust decisions based on these attributes rooted in attestations by trusted authorities.
-
-<figure><img src="../../.gitbook/assets/diagrams.004.jpeg" alt=""><figcaption><p>Please click the diagram to see a bigger version.</p></figcaption></figure>
-
-### Credential Authorities and Enrollment Protocols
-
-Any Ockam Identifier can issue credentials about another Identifier, however some credential authorities are central to the success and scale of a distributed application. For such authorities Ockam Orchestrator offers highly scalable and secure managed credential authorities as a cloud service.
-
-We also have to consider how credentials are issued to a large number of application entities. Ockam offers several pluggable enrollment protocols. Once simple option is to use one-time-use enrollment tokens. This is a great option to enroll large fleets of applications, services, or devices. It is also easy to use with automated provisioning scripts and tools.
-
-<figure><img src="../../.gitbook/assets/diagrams.003.jpeg" alt=""><figcaption><p>Please click the diagram to see a bigger version.</p></figcaption></figure>
-
-### Okta Add-On for Ockam Orchestrator
-
-For most enterprises, workforce identities are already defined in enterprise identity systems like Okta. Ockam Orchestrator offers an Okta Add-On that uses OIDC to allow enterprise employees to get Ockam credentials using their regular corporate login.
-
-Their user profile information like department, city, team etc. is included in the credential and securely attested by the Credential Authority.
-
-This combination is incredibly powerful. It allows **employees to get just-in-time, short lived, fine-grained revocable credentials to only the application components that they need to access.** It eliminates long lived static keys and credentials from being stored on work machines.
+This combination is incredibly powerful. It allows **employees to get just-in-time, short
+lived, fine-grained revocable credentials to only the application components that they
+need to access.** It eliminates long lived static keys and credentials from being stored
+on work machines.
 
 <figure><img src="../../.gitbook/assets/diagrams.003 (1).jpeg" alt=""><figcaption><p>Please click the diagram to see a bigger version.</p></figcaption></figure>
 
-## Step-by-Step Walkthrough
+### Next steps
 
-Let's walk through a simple example of Okta + Ockam in action.
-
-We have a distributed application which has microservice components running in San Francisco and New York. These components have Ockam Identities and Credentials and communicate trustfully using Ockam Secure Channels.
-
-There is a problem in one of the microservices in San Francisco and we need to give Alice (an engineer from San Francisco) secure, short lived, revocable access to just that service and nothing more.
-
-First we'll create our application components and then see how to give access to Alice.
-
-
-### Required Dependencies
-
-Through this example `https://trial-9434859.okta.com/oauth2/default`  refers to an existing okta endpoint where workforce identities are defined.  The okta user profile is expected to contain `email`, `city` and `department` attributes.  These attributes will be included on the generated okcam credentials.
-
-If you don't have an okta install already, you can create a [trial one](https://www.okta.com/free-trial/) to follow this example use case.
-
-
-### Setup
-
-If you use Homebrew, you can install Ockam using `brew`.
-
-```bash
-brew install build-trust/ockam/ockam
-```
-
-Otherwise, you can download our latest architecture specific pre-compiled binary by running:
-
-```shell
-curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/build-trust/ockam/develop/install.sh | sh
-```
-
-After the binary downloads, please move it to a location in your shell's `$PATH`, like `/usr/local/bin`.
-
-### Administrator
-
-Next we provision our system. We enroll with Ockam Orchestrator, enable the Okta Add-On and export the project configuration to share with Alice.
-
-```bash
-ockam enroll
-ockam project addon configure okta \
-  --tenant https://trial-9434859.okta.com/oauth2/default --client-id 0oa2pi8no6Kb04frP697 \
-  --attribute email --attribute city --attribute department
-  
-ockam project information --output json > project.json
-```
-
-This will create a managed Credential Authority for our project.
-
-Next we generate two one-time-use enrollment tokens to enable Machine 1 and 2 to enroll and get credentials. Notice how we specify the attributes to attest for these two machines - `city` and `application`
-
-```
-m1_token=$(ockam project ticket --attribute application="Smart Factory" --attribute city="San Francisco")
-m2_token=$(ockam project ticket --attribute application="Smart Factory" --attribute city="New York")
-```
-
-### Machine 1 in New York
-
-We'll represent the application service on Machine 1 with a simple http server listening on port `5000` but this could be any application service:
-
-```
-python3 -m http.server --bind 127.0.0.1 5000
-```
-
-Next we transfer project configuration and one enrollment token to Machine 1 and use that to create an Ockam node that will run as a sidecar process next to our application service.
-
-```bash
-ockam identity create m1
-ockam project enroll $m1_token --identity m1
-ockam node create m1 --identity m1
-ockam policy create --at m1 --resource tcp-outlet \
-  --expression '(or (= subject.application "Smart Factory") (and (= subject.department "Field Engineering") (= subject.city "San Francisco")))'
-ockam tcp-outlet create --at /node/m1 --from /service/outlet --to 127.0.0.1:5000
-ockam relay create m1 --at /project/default --to /node/m1
-```
-
-We then set an attribute based policy on the tcp-outlet that delivers traffic to our application service. This policy says to allow requests if the subject (the entity requesting access) is part of the same application or if the subject is a Field Engineer based in San Francisco.
-
-```
-(or (= subject.application "Smart Factory")
-    (and (= subject.department "Field Engineering") (= subject.city "San Francisco")))
-```
-
-The first part of the policy allows various application component services to communicate with each other. The second part is what will enable Alice. However, note that there is no mention of Alice here, only a department and a city.
-
-### Machine 2 in San Francisco
-
-We'll represent the application service on Machine 2 with a simple http server listening on port 6`000` but this could be any application service:
-
-```
-python3 -m http.server --bind 127.0.0.1 6000
-```
-
-Next we transfer project configuration and one enrollment token to Machine 2 and use that to create and Ockam node that will run as a sidecar process next to our application service.
-
-```bash
-ockam identity create m2
-ockam project enroll $m2_token --identity m2
-ockam node create m2 --identity m2
-ockam policy create --at m2 --resource tcp-outlet \
-  --expression '(or (= subject.application "Smart Factory") (and (= subject.department "Field Engineering") (= subject.city "New York")))'
-ockam tcp-outlet create --at /node/m2 --from /service/outlet --to 127.0.0.1:6000
-ockam relay create m2 --at /project/default --to /node/m2
-```
-
-Same as before, we then set an attribute based policy on the the tcp-outlet that delivers traffic to our application service. This policy says to allow requests if the subject (the entity requesting access) is part of the same application or if the subject is a Field Engineer based in New York.
-
-```
-(or (= subject.application "Smart Factory")
-    (and (= subject.department "Field Engineering") (= subject.city "New York")))
-```
-
-### Engineer for San Francisco
-
-There is a problem in one of the microservices in San Francisco and we need to give Alice (an engineer from San Francisco) secure, short lived, revocable access to just that service and nothing more.
-
-Since the Okta Add-On is enabled. Alice can simply start a node within the project and authenticate.
-
-```bash
-ockam project enroll --project-path project.json --okta
-ockam node create alice
-ockam policy create --at alice --resource tcp-inlet --expression '(= subject.application "Smart Factory")'
-```
-
-The `project enroll` command will launch Okta login and when it completes return an Ockam cryptographic credential that includes the city and department attributes of Alice's profile in Okta Universal Directory. Only these two attributes are attested because the administrator specified those two attributes when enabling the Okta Add-On.
-
-<figure><img src="../../.gitbook/assets/200395627-827d672a-2140-4752-a8d5-526ec5f0be68.png" alt=""><figcaption><p>User Profile in Okta</p></figcaption></figure>
-
-Alice's `city` in Okta is "San Francisco". Her request to access Machine 1 in San Francisco is allowed
-
-```
-ockam tcp-inlet create --at /node/alice --from 127.0.0.1:8000 \
-  --to /project/default/service/forward_to_m1/secure/api/service/outlet
-curl --head 127.0.0.1:8000
-```
-
-Her request to access Machine 2 in New York is denied.
-
-```
-ockam tcp-inlet create --at /node/alice --from 127.0.0.1:9000 \
-  --to /project/default/service/forward_to_m2/secure/api/service/outlet
-curl --head 127.0.0.1:9000
-
-# this will do nothing and eventually timeout
-```
-
-When new employees join the Field Engineering team in San Francisco, they will get an Okta workforce identity and can also request access to services they are responsible for in San Francisco without any change to the system.
-
-These attribute based policies can easily span the spectrum of very simple to be highly fine-grained and dynamic depending on the needs of an application. At the same time, this approach is highly scalable because it decouples enterprise identity administration from an application's trust policies.
+- See an end-to-end example of this in our
+  [<mark style="color:blue;">Okta AddOn</mark>](../examples/okta.md) demo.
+- Follow our
+  [<mark style="color:blue;">getting started guide to install Ockam</mark>](../../reference/command/README.md#install)
+  and start using it in just a few minutes.
+- [<mark style="color:blue;">Reach out to the team</mark>](https://www.ockam.io/contact/form), we'd
+  love to talk to you in more detail about your potential use cases.
+- Join the growing community of developers who want to build trust by making applications that are
+  secure-by-design, in the
+  [<mark style="color:blue;">Build Trust Discord server</mark>](https://discord.gg/RAbjRr3kds).


### PR DESCRIPTION
Refactor the ABAC, and Okta use case document and extract the code example article out of it.

Use case is framed in this structure
1) Intro
2) Problem
3) How Ockam simplifies it
4) CTA

The implementation details are extracted into a separate files:
1. /guides/examples/okta.md
2. /guides/examples/abac.md

TODO: the README.md for /guides/examples/ needs to be updated in Gitbook web app so that there are no errors syncing this PR into Gitbook using the Git Sync feature.