### PR TITLE
reference: new argument on credential issuer creation

### DIFF
--- a/reference/libraries/rust/credentials.md
+++ b/reference/libraries/rust/credentials.md
@@ -97,6 +97,7 @@ async fn main(ctx: Context) -> Result<()> {
         node.credentials(),
         &issuer,
         "trust_context".into(),
+	None,
     );
 
     let attributes = AttributesEntry::single(b"cluster".to_vec(), b"production".to_vec(), None, None)?;


### PR DESCRIPTION
https://github.com/build-trust/ockam/pull/7387 introduced a new argument to credential issuer creation, to set a desired TTL to issued credentials. If None, the default TTL is used.