### PR TITLE
remove `--alias` argument from `tcp-outlet create` command

### DIFF
--- a/reference/command/advanced-routing.md
+++ b/reference/command/advanced-routing.md
@@ -64,7 +64,7 @@ Continuing from our [<mark style="color:blue;">Relays</mark>](advanced-routing.m
 ```
 » python3 -m http.server --bind 127.0.0.1 9000
 
-» ockam tcp-outlet create --at n3 --from /service/outlet --to 127.0.0.1:9000
+» ockam tcp-outlet create --at n3 --from outlet --to 127.0.0.1:9000
 » ockam tcp-inlet create --at n1 --from 127.0.0.1:6000 \
     --to /worker/603b62d245c9119d584ba3d874eb8108/service/forward_to_n3/service/hop/service/outlet
 

--- a/reference/command/secure-channels.md
+++ b/reference/command/secure-channels.md
@@ -176,7 +176,7 @@ Continuing from the above example on [<mark style="color:blue;">Elastic Encrypte
 ```
 » python3 -m http.server --bind 127.0.0.1 9000
 
-» ockam tcp-outlet create --at a --from /service/outlet --to 127.0.0.1:9000
+» ockam tcp-outlet create --at a --from outlet --to 127.0.0.1:9000
 » ockam secure-channel create --from a --to /project/default/service/forward_to_b/service/api \
     | ockam tcp-inlet create --at a --from 127.0.0.1:6000 --to -/service/outlet
 


### PR DESCRIPTION
Related to the changes done at https://github.com/build-trust/ockam/pull/7572